### PR TITLE
Restructure project to avoid recompilation for executable and library

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,0 +1,6 @@
+module Main where
+
+import DevelMain
+
+main :: IO ()
+main = develMain

--- a/src/DevelMain.hs
+++ b/src/DevelMain.hs
@@ -7,14 +7,14 @@ Maintainer  : njagi@urbanslug.com
 Stability   : experimental
 Portability : POSIX
 -}
-module Main where
+module DevelMain where
 
 import Devel
 import Devel.CmdArgs
 import Options.Applicative
 
-main :: IO ()
-main = do
+develMain :: IO ()
+develMain = do
   cmdArgs' <- execParser opts
 
   let isReverseProxy' = isReverseProxy cmdArgs'

--- a/tests/MainSpec.hs
+++ b/tests/MainSpec.hs
@@ -1,9 +1,8 @@
 -- Tests for Main function.
-{-# LANGUAGE PackageImports #-}
 module MainSpec where
 
 import Test.Hspec
-import "wai-devel" Main as M
+import DevelMain as M
 import Control.Concurrent (forkIO, threadDelay, killThread)
 
 main :: IO ()
@@ -13,7 +12,7 @@ spec :: Spec
 spec = -- How does one test that a bottom effectful computation has done what is expected?
   describe "Program has a working main function" $
     it "Gets cmd arguments from cmdArgs and calls successfully `buildAndRun`." $ do
-      tId <- forkIO M.main
+      tId <- forkIO M.develMain
       threadDelay 100
       killThread tId
       tId `shouldBe` tId

--- a/wai-devel.cabal
+++ b/wai-devel.cabal
@@ -16,7 +16,7 @@ cabal-version:       >=1.10
 library
   ghc-options:         -Wall
   exposed-modules:     Devel
-                     , Main
+                     , DevelMain
                      , Devel.Watch
                      , Devel.CmdArgs
                      , Devel.ReverseProxy
@@ -65,49 +65,12 @@ library
 executable wai-devel
   ghc-options:         -Wall
   main-is:             Main.hs
-  other-modules:       Devel
-                       Devel.CmdArgs
-                       Devel.Build
-                       Devel.Compile
-                       Devel.Config
-                       Devel.Modules
-                       Devel.Paths
-                       Devel.ReverseProxy
-                       Devel.Types
-                       Devel.Watch
+  other-modules:      
   -- other-extensions:
   build-depends:       base
-                     , Cabal-ide-backend
-                     , Glob
-                     , MissingH
-                     , blaze-html
-                     , bytestring
-                     , directory
-                     , filepath
-                     , fsnotify
-                     , ghc
-                     , http-client
-                     , http-conduit
-                     , http-reverse-proxy
-                     , http-types
-                     , ide-backend
-                     , network
-                     , optparse-applicative
-                     , process
-                     , shakespeare
-                     , stm
-                     , streaming-commons
-                     , system-filepath
-                     , text
-                     , time
-                     , transformers
-                     , wai
                      , wai-devel
-                     , warp
-                     , file-embed
-                     , websockets
 
-  hs-source-dirs:      src
+  hs-source-dirs:      app
   default-language:    Haskell2010
 
 test-suite tests


### PR DESCRIPTION
The current project structure has the executable part of the package recompile all of the source code in `src` when building the executable. The modifications in this pull request separate the executable to a different directory, which lets it link against the compiled library. This halves compilation time.
