### PR TITLE
Add -w/--watch-directories.

### DIFF
--- a/src/Devel.hs
+++ b/src/Devel.hs
@@ -19,8 +19,8 @@ import Devel.ReverseProxy (cyclePorts)
 import Devel.Build (build)
 
 -- | Build and run our haskell application.
-buildAndRun :: FilePath -> String ->  Bool -> IO ()
-buildAndRun buildFile runFunction isReverseProxy = do
+buildAndRun :: FilePath -> String -> [String] ->  Bool -> IO ()
+buildAndRun buildFile runFunction watchDirectories isReverseProxy = do
 
   -- set Environment variables: GHC_PACKAGE_PATH and PATH
   -- Needed for ide-backend to provide sessionConfig
@@ -54,7 +54,8 @@ buildAndRun buildFile runFunction isReverseProxy = do
   build
     buildFile -- The target file, should contain the function we wish to call.
     runFunction -- The function we want to call.
-    isReverseProxy -- Use reverse proxying? Default to True. 
+    watchDirectories -- Other directories to watch for file changes in.
+    isReverseProxy -- Use reverse proxying? Default to True.
     sessionConfig -- We need this when compiling.
     (fromProxyPort, toProxyPort) -- The port we reverse proxy to and from.
     Nothing -- Maybe IdeSession

--- a/src/Devel/Build.hs
+++ b/src/Devel/Build.hs
@@ -35,10 +35,10 @@ import Devel.Watch
 
 
 -- | Compiles and calls run on your WAI application.
-build :: FilePath -> String ->  Bool -> SessionConfig -> (Int, Int) -> Maybe IdeSession -> Bool -> IO ()
-build buildFile runFunction isReverseProxy sessionConfig (fromProxyPort, toProxyPort) mSession isRebuild = do
+build :: FilePath -> String ->  [String] -> Bool -> SessionConfig -> (Int, Int) -> Maybe IdeSession -> Bool -> IO ()
+build buildFile runFunction watchDirectories isReverseProxy sessionConfig (fromProxyPort, toProxyPort) mSession isRebuild = do
 
-  (initialSession, extensionList, includeTargets) <- initCompile sessionConfig mSession
+  (initialSession, extensionList, includeTargets, additionalWatch) <- initCompile watchDirectories sessionConfig mSession
 
   -- Do this if isRebuild is False.
   unless isRebuild $
@@ -51,7 +51,7 @@ build buildFile runFunction isReverseProxy sessionConfig (fromProxyPort, toProxy
                  show fromProxyPort
 
 
-  (updatedSession, update) <- 
+  (updatedSession, update) <-
     if isRebuild
        then return (initialSession, mempty)
        else compile initialSession buildFile extensionList includeTargets
@@ -63,18 +63,16 @@ build buildFile runFunction isReverseProxy sessionConfig (fromProxyPort, toProxy
       -- Listen for changes in the current working directory.
       isDirty <- newTVarIO False
 
-      _ <- forkIO $ watch isDirty includeTargets
+      _ <- forkIO $ watch isDirty includeTargets additionalWatch
 
       -- Block until relevant change is made then carry on with program execution.
       _ <- checkForChange isDirty
 
       -- Stop the current app.
       putStrLn "\n\nRebuilding...\n\n"
-      
       _ <- shutdownSession updatedSession
-
       -- Coming to fix.
-      build buildFile runFunction False sessionConfig (fromProxyPort, toProxyPort) Nothing False
+      build buildFile runFunction watchDirectories False sessionConfig (fromProxyPort, toProxyPort) Nothing False
 
     Right session -> do
       -- run the session
@@ -84,17 +82,17 @@ build buildFile runFunction isReverseProxy sessionConfig (fromProxyPort, toProxy
       isDirty <- newTVarIO False
 
       -- Watch for changes in the current working directory.
-      watchId <- forkIO $ watch isDirty includeTargets
+      watchId <- forkIO $ watch isDirty includeTargets additionalWatch
 
       -- Block until relevant change is made then carry on with program execution.
       _ <- checkForChange isDirty
 
       killThread watchId
-      
+
       -- Stop the current app.
       _ <- stopApp runActionsRunResult threadId
       putStrLn "\n\nRebuilding...\n\n"
-      build buildFile runFunction isReverseProxy sessionConfig (fromProxyPort, toProxyPort) (Just session) True
+      build buildFile runFunction watchDirectories isReverseProxy sessionConfig (fromProxyPort, toProxyPort) (Just session) True
 
 
 run :: IdeSession -> FilePath -> String -> IO (RunActions RunResult, ThreadId)

--- a/src/Devel/CmdArgs.hs
+++ b/src/Devel/CmdArgs.hs
@@ -12,14 +12,16 @@ module Devel.CmdArgs
 ,  CmdArgs (..)
 ) where
 
-import Options.Applicative
+import           Data.List.Split     (splitOn)
+import           Options.Applicative
 
 -- | Command line arguments for yesod devel.
 -- All arguments are optional.
 data CmdArgs = CmdArgs
-  { buildFile :: FilePath
-  , runFunction :: String
-  , isReverseProxy :: Bool -- By default reverse proxy should be True 
+  { buildFile        :: FilePath
+  , runFunction      :: String
+  , watchDirectories :: [String]
+  , isReverseProxy   :: Bool -- By default reverse proxy should be True
   } deriving (Show, Eq)
 
 cmdArgs :: Parser CmdArgs
@@ -36,8 +38,13 @@ cmdArgs = CmdArgs
                  <> value "develMain"
                  <> metavar "FUNCTION"
                  <> help "The function you want run. Default is `develMain`.")
+        <*>  (splitOn "," <$> strOption
+                                (long "watch-directories"
+                                  <> short 'w'
+                                  <> value []
+                                  <> metavar "DIRECTORY-LIST"
+                                  <> help "A comma-separated list of directories to watch for any changes (not just .hs files)."))
         <*> flag True False
               (long "no-reverse-proxy"
                 <> short 'r'
                 <> help "use `-r` to disable reverse proxying." )
-        

--- a/src/Devel/Compile.hs
+++ b/src/Devel/Compile.hs
@@ -49,8 +49,8 @@ import Data.Maybe (fromMaybe)
 import Control.Monad (filterM)
 
 -- |Initialize the compilation process.
-initCompile :: SessionConfig -> Maybe IdeSession -> IO (IdeSession, [GhcExtension], [FilePath])
-initCompile sessionConfig mSession = do
+initCompile :: [String] -> SessionConfig -> Maybe IdeSession -> IO (IdeSession, [GhcExtension], [FilePath], [FilePath])
+initCompile watchDirectories sessionConfig mSession = do
   -- Initialize the session
   session <- case mSession of
                Just session -> return session
@@ -61,7 +61,8 @@ initCompile sessionConfig mSession = do
   -- This is "rebuilding" the cabal file.
   (extensionList, srcDir, cabalSrcList) <- getExtensions
   sourceList <- getSourceList srcDir cabalSrcList
-  return (session, extensionList, sourceList)
+  additionalWatchList <- fmap concat (mapM getRecursiveContents watchDirectories)
+  return (session, extensionList, sourceList, additionalWatchList)
 
 getSourceList :: [FilePath] -> [FilePath] -> IO [FilePath]
 getSourceList srcDir cabalSrcList = do

--- a/src/Devel/Watch.hs
+++ b/src/Devel/Watch.hs
@@ -36,13 +36,14 @@ import System.FilePath (pathSeparator)
 
 import Devel.Paths
 
-watch :: TVar Bool -> [FilePath] -> IO ()
-watch isDirty includeTargets = do
+watch :: TVar Bool -> [FilePath] ->  [FilePath] -> IO ()
+watch isDirty watchSource watchOther = do
   -- Get files to watch.
-  files <- getFilesToWatch includeTargets
+  files <- getFilesToWatch watchSource
   -- Making paths to watch a list of absolute paths.
   dir <- getCurrentDirectory
-  let pathsToWatch = map (\fp -> dir ++ (pathSeparator: fp)) files
+  let sourceToWatch = map (\fp -> dir ++ (pathSeparator: fp)) files
+  let otherToWatch = map (\fp -> dir ++ (pathSeparator: fp)) watchOther
 
   -- Actual file watching.
   manager <- startManagerConf defaultConfig
@@ -54,20 +55,20 @@ watch isDirty includeTargets = do
                 getPath (Added fp _)    = fp
                 getPath (Modified fp _) = fp
                 getPath (Removed fp _)  = fp
-                
-                isModified = getPath event `elem` pathsToWatch
-                
-            atomically $ writeTVar isDirty isModified)
-            
+
+                isModified = getPath event `elem` (sourceToWatch ++ otherToWatch)
+            atomically $ do readTVar isDirty >>= check . not
+                            writeTVar isDirty isModified)
+
 #else
-         (\event -> do 
+         (\event -> do
             pathMod' <- case toText $ eventPath event of
                             Right text -> return $ unpack text -- Gives an abs path
                             Left text -> fail $ unpack text
-                            
-            let isModified = pathMod' `elem` pathsToWatch
-            
-            atomically $ writeTVar isDirty isModified)
+
+            let isModified = pathMod' `elem` (sourceToWatch ++ otherToWatch)
+            atomically $ do readTVar isDirty >>= check . not
+                            writeTVar isDirty isModified)
 #endif
 
   _ <- forever $ threadDelay maxBound

--- a/src/DevelMain.hs
+++ b/src/DevelMain.hs
@@ -19,9 +19,10 @@ develMain = do
 
   let isReverseProxy' = isReverseProxy cmdArgs'
       buildFile' = buildFile cmdArgs'
+      watchDirectories' = filter (/= "") $ watchDirectories cmdArgs'
       runFunction' = runFunction cmdArgs'
 
-  buildAndRun buildFile' runFunction' isReverseProxy'
+  buildAndRun buildFile' runFunction' watchDirectories' isReverseProxy'
   where opts :: ParserInfo CmdArgs
         opts = info (helper <*> cmdArgs)
                 (fullDesc

--- a/tests/Devel/CmdArgsSpec.hs
+++ b/tests/Devel/CmdArgsSpec.hs
@@ -11,8 +11,8 @@ spec :: Spec
 spec = do
   describe "Command line arguments." $ do
     it "We can create values of type CmdArgs" $ do
-      let cmdArgs' = CmdArgs "Application.hs" "runDevel" True
-      cmdArgs' `shouldBe` (CmdArgs "Application.hs" "runDevel" True :: CmdArgs)
+      let cmdArgs' = CmdArgs "Application.hs" "runDevel" [] True
+      cmdArgs' `shouldBe` (CmdArgs "Application.hs" "runDevel" [] True :: CmdArgs)
     it "Creates values of type Parser CmdArgs" $ do
       -- How to test that cmdArgs actually creates values of type Parser CmdArgs?
       "to do" `shouldBe` "to do"

--- a/tests/DevelSpec.hs
+++ b/tests/DevelSpec.hs
@@ -16,8 +16,7 @@ spec = -- How does one test that a bottom effectful computation has done what is
     it "buildAndRun is able to pick up the value of PORT" $
       pendingWith "Is it even possible to test for this?"
     it "Successfully calls build. Does not throw an exception." $ do
-      tId <- forkIO $ buildAndRun "Application.hs" "develMain" True
+      tId <- forkIO $ buildAndRun "Application.hs" "develMain" [] True
       threadDelay 100
       killThread tId
       tId `shouldBe` tId
-

--- a/wai-devel.cabal
+++ b/wai-devel.cabal
@@ -7,10 +7,10 @@ license:             GPL-3
 license-file:        LICENSE
 author:              Njagi Mwaniki
 maintainer:          njagi@urbanslug.com
--- copyright:           
+-- copyright:
 category:            Web
 build-type:          Simple
--- extra-source-files:  
+-- extra-source-files:
 cabal-version:       >=1.10
 
 library
@@ -58,6 +58,7 @@ library
                      , warp >= 3.0 && < 3.2
                      , file-embed >= 0.0 && < 0.1
                      , websockets >= 0.9 && < 1.1
+                     , split >= 0.1 && < 0.3
 
   hs-source-dirs:      src
   default-language:    Haskell2010
@@ -65,7 +66,7 @@ library
 executable wai-devel
   ghc-options:         -Wall
   main-is:             Main.hs
-  other-modules:      
+  other-modules:
   -- other-extensions:
   build-depends:       base
                      , wai-devel
@@ -77,7 +78,7 @@ test-suite tests
   ghc-options:         -Wall
   type:                exitcode-stdio-1.0
   main-is:             Spec.hs
-  -- exposed-modules:   
+  -- exposed-modules:
   -- other-modules:       Tests.Watch
   hs-source-dirs:      tests
   build-depends:       base


### PR DESCRIPTION
Any file changes within those directories trigger a reload of the
server. This is useful for templating languages like Heist, but would be
generally useful whenever changes in non-.hs files necessitate reloading
or recompiling the server.

As part of this, I (believe) I fixed a bug that could cause reloads to sometimes not happen - files that are not in the set of files to watch cause events just like other file changes, and so if a file change that should trigger a reload happens, and then shortly after one that shouldn't happen, the second causes the `isDirty` TVar to have `False` written into it. If that happens before the `checkForChange` call happens, then the change is not recognized. I changed it so that the value of `isDirty` is only changed by the watcher if it is currently `False` - as the watcher should never be clearing the dirty statis. 

This addresses (at least partly) #15.
