### PR TITLE
fix remove leading ./ of paths

### DIFF
--- a/src/Devel/Compile.hs
+++ b/src/Devel/Compile.hs
@@ -44,7 +44,7 @@ import Devel.Types
 
 import System.FilePath.Posix (takeExtension, pathSeparator)
 import System.Directory (doesFileExist)
-import Data.List (union, delete, isInfixOf, nub, (\\))
+import Data.List (union, delete, isInfixOf, nub)
 import Data.Maybe (fromMaybe)
 import Control.Monad (filterM)
 
@@ -88,8 +88,8 @@ getSourceList srcDir cabalSrcList = do
       -- nub to remove duplicates yet again.
       sourceList = nub $ delete "app/DevelMain.hs" $ delete "app/devel.hs" sourceList'
 
-  -- Drop leading "./" in filepaths with `map (\x -> x \\ "./") sourceList`
-  return $ map removeLeadingDotSlash sourceList -- sourceList
+  -- Drop leading "./" in filepaths
+  return $ map removeLeadingDotSlash sourceList
     where
         removeLeadingDotSlash ('.':'/':xs) = xs
         removeLeadingDotSlash xs = xs

--- a/src/Devel/Compile.hs
+++ b/src/Devel/Compile.hs
@@ -89,7 +89,11 @@ getSourceList srcDir cabalSrcList = do
       sourceList = nub $ delete "app/DevelMain.hs" $ delete "app/devel.hs" sourceList'
 
   -- Drop leading "./" in filepaths with `map (\x -> x \\ "./") sourceList`
-  return $ map (\x -> x \\ "./") sourceList -- sourceList
+  return $ map removeLeadingDotSlash sourceList -- sourceList
+    where
+        removeLeadingDotSlash ('.':'/':xs) = xs
+        removeLeadingDotSlash xs = xs
+
 
 
 -- | Determining the target files and creating the session update.


### PR DESCRIPTION
The function used to remove leading "./" is wrong:

```
"Foo.hs" \\ "./" = "Foohs"
```

It made `wai-devel` unable to find files to watch in my project.
